### PR TITLE
Added an option menu to launch KDE Connect settings

### DIFF
--- a/src/DeviceIndicator.vala
+++ b/src/DeviceIndicator.vala
@@ -17,6 +17,7 @@ namespace KDEConnectIndicator {
         private Gtk.SeparatorMenuItem separator;
         private Gtk.MenuItem pair_item;
         private Gtk.MenuItem unpair_item;
+        private Gtk.MenuItem settings_item;
         public DeviceIndicator (string path) {
             this.path = path;
             device = new Device (path);
@@ -44,6 +45,8 @@ namespace KDEConnectIndicator {
             menu.append(pair_item);
             unpair_item = new Gtk.MenuItem.with_label ("Unpair");
             menu.append(unpair_item);
+            settings_item = new Gtk.MenuItem.with_label ("KDE Connect Settings");
+            menu.append(settings_item);
 
             menu.show_all ();
 
@@ -77,6 +80,12 @@ namespace KDEConnectIndicator {
             });
             unpair_item.activate.connect (() => {
                 device.unpair ();
+            });
+            settings_item.activate.connect (() => {
+                try {
+                    Process.spawn_command_line_async ("kcmshell4 kdeconnect");
+                } catch (Error e) {
+                }
             });
 
             device.charge_changed.connect ((charge) => {


### PR DESCRIPTION
I found that there is no easy way to launch KDE Connect settings in non-KDE desktops.

What do you think about adding it as a menu item to the tray icons?
