### PR TITLE
Adapt to changes in upstream kdeconnect-kde master

### DIFF
--- a/src/Device.vala
+++ b/src/Device.vala
@@ -234,20 +234,9 @@ namespace KDEConnectIndicator {
         }
         public bool is_reachable () {
             try {
-                var return_variant = conn.call_sync (
-                        "org.kde.kdeconnect",
-                        path,
-                        "org.kde.kdeconnect.device",
-                        "isReachable",
-                        null,
-                        null,
-                        DBusCallFlags.NONE,
-                        -1,
-                        null
-                        );
-                Variant i = return_variant.get_child_value (0);
-                if (i!=null)
-                    return i.get_boolean ();
+                Variant return_variant=device_proxy.get_cached_property ("isReachable");
+                if (return_variant!=null)
+                    return return_variant.get_boolean ();
             } catch (Error e) {
                 message (e.message);
             }

--- a/src/KDEConnectManager.vala
+++ b/src/KDEConnectManager.vala
@@ -70,8 +70,39 @@ namespace KDEConnectIndicator {
                     );
             subs_identifier.append (id);
 
+            try {
+                conn.call_sync (
+                        "org.kde.kdeconnect",
+                        "/modules/kdeconnect",
+                        "org.kde.kdeconnect.daemon",
+                        "acquireDiscoveryMode",
+                        new Variant ("(s)", "Indicator-KDEConnect"),
+                        null,
+                        DBusCallFlags.NONE,
+                        -1,
+                        null
+                        );
+            } catch (Error e) {
+                message (e.message);
+            }
         }
         ~KDEConnectManager () {
+            try {
+                conn.call_sync (
+                        "org.kde.kdeconnect",
+                        "/modules/kdeconnect",
+                        "org.kde.kdeconnect.daemon",
+                        "releaseDiscoveryMode",
+                        new Variant ("(s)", "Indicator-KDEConnect"),
+                        null,
+                        DBusCallFlags.NONE,
+                        -1,
+                        null
+                        );
+            } catch (Error e) {
+                message (e.message);
+            }
+
             foreach (uint i in subs_identifier)
                 conn.signal_unsubscribe (i);
         }
@@ -97,7 +128,8 @@ namespace KDEConnectIndicator {
             msg.run ();
         }
         private void run_kdeconnect_binary () {
-            File f = File.new_for_path ("/usr/lib/kde4/libexec/kdeconnectd");
+            //TODO: shouldn't hardcode the path
+            File f = File.new_for_path ("/usr/lib/libexec/kdeconnectd");
             if (f.query_exists ()) {
                 try {
                     Process.spawn_command_line_sync (f.get_path ());


### PR DESCRIPTION
Device::isReachable now is a property
(Hopefully) fixes a hardcoded path.
Adopts the discovery acquire/release idiom
