### PR TITLE
isReachable/isPaired as properties, correct icon

### DIFF
--- a/src/Device.vala
+++ b/src/Device.vala
@@ -37,7 +37,7 @@ namespace KDEConnectIndicator {
         }
         public string icon_name {
             get {
-                Variant return_variant=device_proxy.get_cached_property ("iconName");
+                Variant return_variant=device_proxy.get_cached_property ("statusIconName");
                 if (return_variant!=null && return_variant.get_string () != "")
                     return return_variant.get_string ();
                 return "smartphone"; // default to smartphone as KDC 0.5 doens't have icon name props
@@ -222,47 +222,21 @@ namespace KDEConnectIndicator {
                 message (e.message);
             }
         }
-        public bool is_paired () {
-            try {
-                var return_variant = conn.call_sync (
-                        "org.kde.kdeconnect",
-                        path,
-                        "org.kde.kdeconnect.device",
-                        "isPaired",
-                        null,
-                        null,
-                        DBusCallFlags.NONE,
-                        -1,
-                        null
-                        );
-                Variant i = return_variant.get_child_value (0);
-                if (i!=null)
-                    return i.get_boolean ();
-            } catch (Error e) {
-                message (e.message);
-            }
-            return false;
+        public bool is_paired {
+			get {
+				Variant return_variant=device_proxy.get_cached_property ("isPaired");
+				if (return_variant!=null)
+					return return_variant.get_boolean ();
+				return false; // default to false if something went wrong
+			}
         }
-        public bool is_reachable () {
-            try {
-                var return_variant = conn.call_sync (
-                        "org.kde.kdeconnect",
-                        path,
-                        "org.kde.kdeconnect.device",
-                        "isReachable",
-                        null,
-                        null,
-                        DBusCallFlags.NONE,
-                        -1,
-                        null
-                        );
-                Variant i = return_variant.get_child_value (0);
-                if (i!=null)
-                    return i.get_boolean ();
-            } catch (Error e) {
-                message (e.message);
-            }
-            return false;
+        public bool is_reachable {
+			get {
+				Variant return_variant=device_proxy.get_cached_property ("isReachable");
+				if (return_variant!=null)
+					return return_variant.get_boolean ();
+				return false; // default to false if something went wrong
+			}
         }
         public bool is_charging () {
             if (!has_plugin ("kdeconnect_battery"))

--- a/src/DeviceIndicator.vala
+++ b/src/DeviceIndicator.vala
@@ -24,7 +24,7 @@ namespace KDEConnectIndicator {
 
             indicator = new AppIndicator.Indicator (
                     path,
-                    device.icon_name + "-symbolic",
+                    device.icon_name,
                     AppIndicator.IndicatorCategory.HARDWARE);
 
             name_item = new Gtk.MenuItem ();
@@ -120,7 +120,7 @@ namespace KDEConnectIndicator {
         }
 
         private void update_visibility () {
-            if (!device.is_reachable ())
+            if (!device.is_reachable)
                 indicator.set_status (AppIndicator.IndicatorStatus.PASSIVE);
             else
                 indicator.set_status (AppIndicator.IndicatorStatus.ACTIVE);
@@ -129,8 +129,8 @@ namespace KDEConnectIndicator {
             name_item.label = device.name;
         }
         private void update_battery_item () {
-            battery_item.visible = device.is_paired ()
-                && device.is_reachable ()
+            battery_item.visible = device.is_paired
+                && device.is_reachable
                 && device.has_plugin ("kdeconnect_battery");
             this.battery_item.label = "Battery : %d%%".printf(device.battery);
             if (device.is_charging ())
@@ -138,13 +138,13 @@ namespace KDEConnectIndicator {
         }
         private void update_status_item () {
 
-            if (device.is_reachable ()) {
-                if (device.is_paired ())
+            if (device.is_reachable) {
+                if (device.is_paired)
                     this.status_item.label = "Device Reachable and Paired";
                 else
                     this.status_item.label = "Device Reachable but Not Paired";
             } else {
-                if (device.is_paired ())
+                if (device.is_paired)
                     this.status_item.label = "Device Paired but not Reachable";
                 else
                     // is this even posible?
@@ -152,8 +152,8 @@ namespace KDEConnectIndicator {
             }
         }
         private void update_pair_item () {
-            var paired = device.is_paired ();
-            var reachable = device.is_reachable ();
+            var paired = device.is_paired;
+            var reachable = device.is_reachable;
             pair_item.visible = !paired;
             unpair_item.visible = paired;
 

--- a/src/contractor/Contractor.vala
+++ b/src/contractor/Contractor.vala
@@ -105,7 +105,7 @@ namespace KDEConnectIndicator {
         var device_list = new SList<Device> ();
         foreach (string id in id_list) {
             var d = new Device ("/modules/kdeconnect/devices/"+id);
-            if (d.is_reachable () && d.is_paired ()) {
+            if (d.is_reachable && d.is_paired) {
                 device_list.append (d);
                 Gtk.TreeIter iter;
                 list_store.append (out iter);


### PR DESCRIPTION
This change switches is_reachable and is_paired to fetch the properties
instead of trying to call a method.  (not sure if/when this changed in
the dbus interface, but that's how they are presented for me)

This fixes issue #31 and (I think) #38

This also switches the icon code to use the statusIconName as that seems
to have the correct value.  Also, in DeviceIndicator, no longer append
"-symbolic" as (at least on my system) the icons don't seem to have
that in their names.

(If you'd like these separated, let me know)
